### PR TITLE
Support plugging a custom axios instance

### DIFF
--- a/src/axiosWrapper.js
+++ b/src/axiosWrapper.js
@@ -1,0 +1,20 @@
+/**
+ * Axios Wrapper to allow plugging a custom instance.
+ */
+
+const axios = require('axios');
+const os = require('os');
+const pkg = require('./../package.json');
+
+const userAgentString = `node-${pkg.name}/${pkg.version} (${os.type()} ${os.release()})`;
+
+let instance = axios.create();
+instance.defaults.headers.common['User-Agent'] = userAgentString;
+
+exports.getInstance = function() {
+    return instance;
+};
+
+exports.setInstance = function(newInstance) {
+    instance = newInstance;
+};

--- a/src/http.js
+++ b/src/http.js
@@ -3,15 +3,10 @@
  */
 
 const crypto = require('crypto');
-const os = require('os');
-const axios = require('axios');
 const debug = require('debug')('acme-client');
+const axiosWrapper = require('./axiosWrapper');
 const helper = require('./helper');
 const forge = require('./crypto/forge');
-const pkg = require('./../package.json');
-
-const userAgentString = `node-${pkg.name}/${pkg.version} (${os.type()} ${os.release()})`;
-
 
 /**
  * ACME HTTP client
@@ -50,10 +45,9 @@ class HttpClient {
         }
 
         opts.headers['Content-Type'] = 'application/jose+json';
-        opts.headers['User-Agent'] = userAgentString;
 
         debug(`HTTP request: ${method} ${url}`);
-        const resp = await axios.request(opts);
+        const resp = await axiosWrapper.getInstance().request(opts);
 
         debug(`RESP ${resp.status} ${method} ${url}`);
         return resp;

--- a/src/index.js
+++ b/src/index.js
@@ -23,3 +23,8 @@ exports.directory = {
 
 exports.forge = require('./crypto/forge');
 exports.openssl = require('./crypto/openssl');
+
+/**
+ * Axios Wrapper
+ */
+exports.axiosWrapper = require('./axiosWrapper');

--- a/src/verify.js
+++ b/src/verify.js
@@ -4,8 +4,8 @@
 
 const Promise = require('bluebird');
 const dns = Promise.promisifyAll(require('dns'));
-const axios = require('axios');
 const debug = require('debug')('acme-client');
+const axiosWrapper = require('./axiosWrapper');
 
 
 /**
@@ -23,7 +23,7 @@ const debug = require('debug')('acme-client');
 async function verifyHttpChallenge(authz, challenge, keyAuthorization, suffix = `/.well-known/acme-challenge/${challenge.token}`) {
     debug(`Sending HTTP query to ${authz.identifier.value}, suffix: ${suffix}`);
     const challengeUrl = `http://${authz.identifier.value}${suffix}`;
-    const resp = await axios.get(challengeUrl);
+    const resp = await axiosWrapper.getInstance().get(challengeUrl);
 
     debug(`Query successful, HTTP status code: ${resp.status}`);
 

--- a/test/15-axiosWrapper.spec.js
+++ b/test/15-axiosWrapper.spec.js
@@ -1,0 +1,40 @@
+/**
+ * Axios Wrapper Test.
+ */
+
+const axios = require('axios');
+const assert = require('chai').assert;
+const nock = require('nock');
+const axiosWrapper = require('../src/axiosWrapper');
+
+
+describe('axiosWrapper', () => {
+    it('should send a User-Agent header by default', async () => {
+        nock('http://www.example.com', {
+            reqheaders: {
+                'User-Agent': /^node-.*$/
+            }
+        })
+            .get('/')
+            .reply(200, 'success');
+        const response = await axiosWrapper.getInstance().get('http://www.example.com/');
+        assert.equal(response.status, 200);
+    });
+
+    it('should allow swapping out the axios instance', async () => {
+        nock('http://www.example.com', {
+            reqheaders: {
+                'User-Agent': /^custom$/
+            }
+        })
+            .get('/')
+            .reply(200, 'success');
+
+        const instance = axios.create();
+        instance.defaults.headers.common['User-Agent'] = 'custom';
+        axiosWrapper.setInstance(instance);
+
+        const response = await axiosWrapper.getInstance().get('http://www.example.com/');
+        assert.equal(response.status, 200);
+    });
+});


### PR DESCRIPTION
Support plugging a custom Axios instance to allow customizing the behavior of outgoing HTTP requests.

1. The current implementation of outgoing HTTP requests forcefully sets an `User-Agent` header that leaks a bunch of information about the system. Setting a custom `User-Agent` in `axios.defaults.headers.common` does not work, because the explicit one in `acme-client` takes precedence. By being able to specify a custom instance this works.
2. It allows to specify an HTTP proxy specifically for Acme requests.

Example usage:

```js
const axios = require('axios');
const instance = axios.create();
instance.defaults.proxy = { host: '127.0.0.1', port: 9000 };

const acme = require('acme-client');
acme.axiosWrapper.setInstance(instance);
```

or


```js
const acme = require('acme-client');
const instance = acme.axiosWrapper.getInstance();
instance.defaults.proxy = { host: '127.0.0.1', port: 9000 };
```