### PR TITLE
forge: Allow characters not in PrintableString for Subject of CSR

### DIFF
--- a/src/crypto/forge.js
+++ b/src/crypto/forge.js
@@ -210,7 +210,12 @@ exports.readCertificateInfo = async function(cert) {
 function createCsrSubject(subjectObj) {
     return Object.entries(subjectObj).reduce((result, [shortName, value]) => {
         if (value) {
-            result.push({ shortName, value });
+            if (shortName !== 'C') {
+                result.push({ shortName, value, valueTagClass: forge.asn1.Type.UTF8 });
+            }
+            else {
+                result.push({ shortName, value });
+            }
         }
 
         return result;


### PR DESCRIPTION
Default encoding of node-forge for string in CSR is PrintableString,
but that is too restrictive. With UTF8String, we can use wildcard
domain name in CN an non-ASCII name in O and OU.

But, we still need to use PrintableString for 'C' (country name).

References:
RFC5280: https://tools.ietf.org/html/rfc5280