### PR TITLE
use POST-as-GET requests

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -189,7 +189,7 @@ class AcmeApi {
      */
 
     getAuthorization(url) {
-        return this.get(url, [200]);
+        return this.apiRequest('', null, 'post', [200], true, url);
     }
 
 

--- a/src/client.js
+++ b/src/client.js
@@ -371,7 +371,7 @@ class AcmeClient {
         }
 
         const verifyFn = async (abort) => {
-            const resp = await this.api.get(item.url, [200]);
+            const resp = await this.api.apiRequest('', null, 'post', [200], true, item.url);
 
             /* Verify status */
             debug(`Item has status: ${resp.data.status}`);
@@ -413,7 +413,7 @@ class AcmeClient {
             throw new Error('Unable to download certificate, URL not found');
         }
 
-        const resp = await this.http.request(order.certificate, 'get', { responseType: 'text' });
+        const resp = await this.api.apiRequest('', null, 'post', [200], true, order.certificate);
         return resp.data;
     }
 

--- a/src/http.js
+++ b/src/http.js
@@ -165,10 +165,19 @@ class HttpClient {
         }
 
         /* Request payload */
-        const result = {
-            payload: util.b64encode(JSON.stringify(payload)),
-            protected: util.b64encode(JSON.stringify(header))
-        };
+        let result;
+        if (payload === "") {
+            result = {
+                payload: "",
+                protected: util.b64encode(JSON.stringify(header))
+            };
+        }
+        else {
+            result = {
+                payload: util.b64encode(JSON.stringify(payload)),
+                protected: util.b64encode(JSON.stringify(header))
+            };
+        }
 
         /* Signature */
         const signer = crypto.createSign('RSA-SHA256').update(`${result.protected}.${result.payload}`, 'utf8');

--- a/src/http.js
+++ b/src/http.js
@@ -166,9 +166,9 @@ class HttpClient {
 
         /* Request payload */
         let result;
-        if (payload === "") {
+        if (payload === '') {
             result = {
-                payload: "",
+                payload: '',
                 protected: util.b64encode(JSON.stringify(header))
             };
         }


### PR DESCRIPTION
I was testing this client against an [open source internal CA](https://github.com/smallstep/certificates) I'm working on that supports ACME and it wasn't working. I noticed that some requests that should be [`POST-as-GET` requests](https://tools.ietf.org/html/rfc8555#section-6.3) per the ACME spec were being set as plain `GET` requests. This PR contains the bare minimum changes I needed to get things working.