### PR TITLE
add getOrder function to get the current status of an order

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -37,6 +37,7 @@ AcmeClient
     * [.updateAccount([data])](#AcmeClient+updateAccount) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.updateAccountKey(newAccountKey, [data])](#AcmeClient+updateAccountKey) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.createOrder(data)](#AcmeClient+createOrder) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [.getOrder(order)](#AcmeClient+getOrder) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.finalizeOrder(order, csr)](#AcmeClient+finalizeOrder) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.getAuthorizations(order)](#AcmeClient+getAuthorizations) ⇒ <code>Promise.&lt;Array.&lt;object&gt;&gt;</code>
     * [.deactivateAuthorization(authz)](#AcmeClient+deactivateAuthorization) ⇒ <code>Promise.&lt;object&gt;</code>
@@ -132,6 +133,20 @@ https://tools.ietf.org/html/rfc8555#section-7.4
 | Param | Type | Description |
 | --- | --- | --- |
 | data | <code>object</code> | Request data |
+
+<a name="AcmeClient+getOrder"></a>
+
+### acmeClient.getOrder(order) ⇒ <code>Promise.&lt;object&gt;</code>
+Get status of order
+
+https://tools.ietf.org/html/rfc8555#section-7.4
+
+**Kind**: instance method of [<code>AcmeClient</code>](#AcmeClient)  
+**Returns**: <code>Promise.&lt;object&gt;</code> - Order  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| order | <code>object</code> | Order object |
 
 <a name="AcmeClient+finalizeOrder"></a>
 

--- a/src/api.js
+++ b/src/api.js
@@ -152,6 +152,21 @@ class AcmeApi {
 
 
     /**
+     * Get order
+     *
+     * https://tools.ietf.org/html/rfc8555#section-7.4
+     *
+     * @param {string} url Order URL
+     * @param {object} data Request payload
+     * @returns {Promise<object>} HTTP response
+     */
+
+    getOrder(url, data) {
+        return this.apiRequest(url, null, [200]);
+    }
+
+
+    /**
      * Finalize order
      *
      * https://tools.ietf.org/html/rfc8555#section-7.4

--- a/src/api.js
+++ b/src/api.js
@@ -157,11 +157,10 @@ class AcmeApi {
      * https://tools.ietf.org/html/rfc8555#section-7.4
      *
      * @param {string} url Order URL
-     * @param {object} data Request payload
      * @returns {Promise<object>} HTTP response
      */
 
-    getOrder(url, data) {
+    getOrder(url) {
         return this.apiRequest(url, null, [200]);
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -212,6 +212,26 @@ class AcmeClient {
 
 
     /**
+     * Get status of order
+     *
+     * https://tools.ietf.org/html/rfc8555#section-7.4
+     *
+     * @param {object} order Order object
+     * @returns {Promise<object>} Order
+     */
+
+    async getOrder(order) {
+        if (!order.url) {
+            throw new Error('Unable to get order, URL not found');
+        }
+
+        const resp = await this.api.getOrder(order.url);
+        /* Add URL to response */
+        resp.data.url = order.url;
+        return resp.data;
+    }
+
+    /**
      * Finalize order
      *
      * https://tools.ietf.org/html/rfc8555#section-7.4

--- a/test/50-client.spec.js
+++ b/test/50-client.spec.js
@@ -238,6 +238,41 @@ describe('client', () => {
 
 
     /**
+     * Get status of existing certificate order
+     */
+
+    it('should get existing order', async () => {
+        const data1 = { identifiers: [{ type: 'dns', value: testDomain }] };
+        const data2 = { identifiers: [{ type: 'dns', value: testDomainWildcard }] };
+
+        testOrder = await testClient.createOrder(data1);
+        testOrderWildcard = await testClient.createOrder(data2);
+
+        testGetOrder = await testClient.getOrder({ url: testOrder.url });
+        testGetOrderWildcard = await testClient.getOrder({ url: testOrderWildcard.url });
+
+        [
+            {createOrder: testOrder, getOrder: testGetOrder},
+            {createOrder: testOrderWildcard, getOrder: testGetOrderWildcard},
+        ].forEach(({createOrder, getOrder}) => {
+            assert.isObject(getOrder);
+            assert.strictEqual(createOrder.status, getOrder.status);
+
+            assert.isArray(getOrder.identifiers);
+            assert.isArray(getOrder.authorizations);
+            
+            assert.deepEqual(createOrder.identifiers.sort(),getOrder.identifiers.sort());
+            assert.deepEqual(createOrder.authorizations.sort(),getOrder.authorizations.sort());
+
+            assert.isString(getOrder.url);
+            assert.strictEqual(createOrder.url, getOrder.url);
+            assert.isString(getOrder.finalize);
+            assert.strictEqual(createOrder.finalize, getOrder.finalize);
+        });
+    });
+
+
+    /**
      * Get identifier authorization
      */
 

--- a/test/50-client.spec.js
+++ b/test/50-client.spec.js
@@ -242,27 +242,21 @@ describe('client', () => {
      */
 
     it('should get existing order', async () => {
-        const data1 = { identifiers: [{ type: 'dns', value: testDomain }] };
-        const data2 = { identifiers: [{ type: 'dns', value: testDomainWildcard }] };
-
-        testOrder = await testClient.createOrder(data1);
-        testOrderWildcard = await testClient.createOrder(data2);
-
-        testGetOrder = await testClient.getOrder({ url: testOrder.url });
-        testGetOrderWildcard = await testClient.getOrder({ url: testOrderWildcard.url });
+        const testGetOrder = await testClient.getOrder({ url: testOrder.url });
+        const testGetOrderWildcard = await testClient.getOrder({ url: testOrderWildcard.url });
 
         [
-            {createOrder: testOrder, getOrder: testGetOrder},
-            {createOrder: testOrderWildcard, getOrder: testGetOrderWildcard},
-        ].forEach(({createOrder, getOrder}) => {
+            { createOrder: testOrder, getOrder: testGetOrder },
+            { createOrder: testOrderWildcard, getOrder: testGetOrderWildcard }
+        ].forEach(({ createOrder, getOrder }) => {
             assert.isObject(getOrder);
             assert.strictEqual(createOrder.status, getOrder.status);
 
             assert.isArray(getOrder.identifiers);
             assert.isArray(getOrder.authorizations);
-            
-            assert.deepEqual(createOrder.identifiers.sort(),getOrder.identifiers.sort());
-            assert.deepEqual(createOrder.authorizations.sort(),getOrder.authorizations.sort());
+
+            assert.deepEqual(createOrder.identifiers.sort(), getOrder.identifiers.sort());
+            assert.deepEqual(createOrder.authorizations.sort(), getOrder.authorizations.sort());
 
             assert.isString(getOrder.url);
             assert.strictEqual(createOrder.url, getOrder.url);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,6 +60,7 @@ export class Client {
     updateAccount(data?: rfc8555.AccountUpdateRequest): Promise<rfc8555.Account>;
     updateAccountKey(newAccountKey: PrivateKeyBuffer | PrivateKeyString, data?: object): Promise<rfc8555.Account>;
     createOrder(data: rfc8555.OrderCreateRequest): Promise<Order>;
+    getOrder(order: Order): Promise<Order>;
     finalizeOrder(order: Order, csr: CsrBuffer | CsrString): Promise<Order>;
     getAuthorizations(order: Order): Promise<Authorization[]>;
     deactivateAuthorization(authz: Authorization): Promise<Authorization>;

--- a/types/test.ts
+++ b/types/test.ts
@@ -27,6 +27,7 @@ import * as acme from 'acme-client';
             { type: 'dns', value: '*.example.com' },
         ]
     });
+    await client.getOrder(order);
 
     /* Authorizations / Challenges */
     const authorizations = await client.getAuthorizations(order);


### PR DESCRIPTION
Adds the `getOrder` function which allows a system to query the CA to double-check the status of an order.

This is important in parallelized systems where workers may not know the current status of an order (or the status may be out of date.) As a result, a worker may try to finalize an order that has already been finalized, which causes a server-side error. Most other endpoints do not create errors in the CA if called out of order.  

To prevent workers from accidentally calling endpoints out of order and triggering an error, a worker should get the current status of the order, then continue working on it based on the CA's reported status of the order. If the order status is 'valid', the client should just request a certificate and not try to finalize or authorize the order. The same logic would apply if the order is in a 'ready' state, the users can jump right to `finalize` without repeating the authz steps.

Let's Encrypt topic on this: [Does resubmitting the same CSR affect rate limits?](https://community.letsencrypt.org/t/does-resubmitting-the-same-csr-affect-rate-limits/137566/11?u=bryanvaz)

_Note: New PR uses dedicated branch in fork repo_

**Updated with test cases for new function**

Cheers,
Bryan