### PR TITLE
Add EAB support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,17 @@ commands:
           background: true
 
       - run:
+          name: Start Pebble with EAB
+          command: /tmp/pebble -strict -config /tmp/pebble-config-external-account-bindings.json -dnsserver "127.0.0.1:8053"
+          background: true
+
+      - run:
           name: Set up environment
           command: |
             echo 'export NODE_EXTRA_CA_CERTS="/tmp/ca.cert.pem"' >> $BASH_ENV
             echo 'export ACME_CA_CERT_PATH="/tmp/ca.cert.pem"' >> $BASH_ENV
             echo 'export ACME_DIRECTORY_URL="https://127.0.0.1:14000/dir"' >> $BASH_ENV
+            echo 'export ACME_EAB_DIRECTORY_URL="https://127.0.0.1:24000/dir"' >> $BASH_ENV
 
       - run:
           name: Wait for Pebble
@@ -89,6 +95,10 @@ commands:
             ACME_TLSALPN_PORT: 5001
             ACME_HTTP_PORT: 5002
             ACME_HTTPS_PORT: 5003
+            ACME_EAB_TLSALPN_PORT: 25001
+            ACME_EAB_HTTP_PORT: 25002
+            ACME_EAB_HTTPS_PORT: 25003
+
 
 jobs:
   v10: { docker: [{ image: circleci/node:10 }], steps: [ pre, install-cts, install-pebble, test ]}

--- a/docs/client.md
+++ b/docs/client.md
@@ -56,11 +56,14 @@ AcmeClient
 | --- | --- | --- |
 | opts | <code>object</code> |  |
 | opts.directoryUrl | <code>string</code> | ACME directory URL |
-| opts.accountKey | <code>buffer</code> \| <code>string</code> | PEM encoded account private key |
+| opts.accountKey | <code>buffer</code> \| <code>string</code> | PEM encoded account private key (only `RS256` currently supported) |
 | [opts.accountUrl] | <code>string</code> | Account URL, default: `null` |
 | [opts.backoffAttempts] | <code>number</code> | Maximum number of backoff attempts, default: `5` |
 | [opts.backoffMin] | <code>number</code> | Minimum backoff attempt delay in milliseconds, default: `5000` |
 | [opts.backoffMax] | <code>number</code> | Maximum backoff attempt delay in milliseconds, default: `30000` |
+| [opts.externalAccountBinding] | <code>object</code> | EAB credentials attached to the new-account request, default: null |
+| opts.externalAccountBinding.kid | <code>object</code> | EAB KID provided by CA |
+| opts.externalAccountBinding.key | <code>object</code> | EAB HMAC Key ('secret') provided by CA (only `HS256` currently supported) |
 
 <a name="AcmeClient+getTermsOfServiceUrl"></a>
 

--- a/scripts/test-suite-install-pebble.sh
+++ b/scripts/test-suite-install-pebble.sh
@@ -11,6 +11,10 @@ wget -nv "https://raw.githubusercontent.com/letsencrypt/pebble/v${PEBBLE_VERSION
 wget -nv "https://raw.githubusercontent.com/letsencrypt/pebble/v${PEBBLE_VERSION}/test/certs/localhost/key.pem" -O /tmp/key.pem
 wget -nv "https://raw.githubusercontent.com/letsencrypt/pebble/v${PEBBLE_VERSION}/test/config/pebble-config.json" -O /tmp/pebble.json
 
+# Pebble config with EAB enabled
+# wget -nv "https://raw.githubusercontent.com/letsencrypt/pebble/v${PEBBLE_VERSION}/test/config/pebble-config-external-account-bindings.json" -O /tmp/pebble.json
+
+
 # Download Pebble
 wget -nv "https://github.com/letsencrypt/pebble/releases/download/v${PEBBLE_VERSION}/pebble_linux-amd64" -O /tmp/pebble
 

--- a/scripts/test-suite-install-pebble.sh
+++ b/scripts/test-suite-install-pebble.sh
@@ -12,7 +12,7 @@ wget -nv "https://raw.githubusercontent.com/letsencrypt/pebble/v${PEBBLE_VERSION
 wget -nv "https://raw.githubusercontent.com/letsencrypt/pebble/v${PEBBLE_VERSION}/test/config/pebble-config.json" -O /tmp/pebble.json
 
 # Pebble config with EAB enabled
-# wget -nv "https://raw.githubusercontent.com/letsencrypt/pebble/v${PEBBLE_VERSION}/test/config/pebble-config-external-account-bindings.json" -O /tmp/pebble.json
+wget -nv "https://raw.githubusercontent.com/letsencrypt/pebble/v${PEBBLE_VERSION}/test/config/pebble-config-external-account-bindings.json" -O /tmp/pebble-config-external-account-bindings.json
 
 
 # Download Pebble
@@ -20,6 +20,11 @@ wget -nv "https://github.com/letsencrypt/pebble/releases/download/v${PEBBLE_VERS
 
 # Config and permissions
 sed -i 's/test\/certs\/localhost/\/tmp/' /tmp/pebble.json
+sed -i 's/test\/certs\/localhost/\/tmp/' /tmp/pebble-config-external-account-bindings.json
+sed -i 's/:14000/:24000/' /tmp/pebble-config-external-account-bindings.json
+sed -i 's/:15000/:25000/' /tmp/pebble-config-external-account-bindings.json
+sed -i 's/:5002/:25002/' /tmp/pebble-config-external-account-bindings.json
+sed -i 's/:5001/:25001/' /tmp/pebble-config-external-account-bindings.json
 chmod +x /tmp/pebble
 
 exit 0

--- a/scripts/test-suite-wait-for-ca.sh
+++ b/scripts/test-suite-wait-for-ca.sh
@@ -23,6 +23,25 @@ while ! $(curl --cacert "${ACME_CA_CERT_PATH}" -s -D - "${ACME_DIRECTORY_URL}" |
     sleep 1
 done
 
+if [ -z ${ACME_EAB_DIRECTORY_URL+x} ]; then
+    echo "ACME_EAB_DIRECTORY_URL not set"
+else
+    # Loop until ready
+    while ! $(curl --cacert "${ACME_CA_CERT_PATH}" -s -D - "${ACME_EAB_DIRECTORY_URL}" | grep '^HTTP.*200' > /dev/null 2>&1); do
+        ATTEMPT=$((ATTEMPT + 1))
+
+        # Max attempts
+        if [[ $ATTEMPT -gt $MAX_ATTEMPTS ]]; then
+            echo "[!] Waited ${ATTEMPT} attempts for EAB server to become ready, exit 1"
+            exit 1
+        fi
+
+        # Retry
+        echo "[-] Waiting 1 second for EAB server to become ready, attempt: ${ATTEMPT}/${MAX_ATTEMPTS}, check: ${ACME_EAB_DIRECTORY_URL}, cert: ${ACME_CA_CERT_PATH}"
+        sleep 1
+    done
+fi
+
 # Ready
 echo "[+] Server ready!"
 exit 0

--- a/src/api.js
+++ b/src/api.js
@@ -107,13 +107,13 @@ class AcmeApi {
 
         // Add externalAccountBinding info if present
         // TODO: fold into generic http function
-        if(this.eabKey && this.eabKid){
+        if (this.eabKey && this.eabKid) {
             const url = await this.http.getResourceUrl(resource);
             /* EAB JWS header */
             const eabHeader = {
                 url,
                 alg: 'HS256',
-                kid: this.eabKid,
+                kid: this.eabKid
             };
             /* EAB JWS payload which is just the outer JWS's jwk field in base64 */
             const accJwk = await this.http.getJwk();
@@ -121,10 +121,10 @@ class AcmeApi {
 
             const eabJws = {
                 protected: util.b64encode(JSON.stringify(eabHeader)),
-                payload: eabPayload,
-            }
+                payload: eabPayload
+            };
 
-            /* 
+            /*
             Signature with HMAC256
             See: https://github.com/auth0/node-jwa/blob/8ddd78abc5ebfbb7914e3d1ce5edae1e69f74e8d/index.js#L128
             */
@@ -134,8 +134,8 @@ class AcmeApi {
 
             payload.externalAccountBinding = {
                 ...eabJws,
-                signature,
-            }
+                signature
+            };
         }
 
         const resp = await this.apiResourceRequest(resource, payload, [200, 201], false);

--- a/src/api.js
+++ b/src/api.js
@@ -128,16 +128,15 @@ class AcmeApi {
             Signature with HMAC256
             See: https://github.com/auth0/node-jwa/blob/8ddd78abc5ebfbb7914e3d1ce5edae1e69f74e8d/index.js#L128
             */
-            const signature = crypto.createHmac('sha256', this.eabKey)
+            const signatureBuffer = crypto.createHmac('sha256', Buffer.from(this.eabKey, 'base64'))
                 .update(`${eabJws.protected}.${eabJws.payload}`, 'utf8')
-                .digest('base64');
+                .digest();
 
             payload.externalAccountBinding = {
                 ...eabJws,
-                signature
+                signature: util.b64encode(signatureBuffer)
             };
         }
-
         const resp = await this.apiResourceRequest(resource, payload, [200, 201], false);
 
         /* Set account URL */

--- a/src/client.js
+++ b/src/client.js
@@ -35,14 +35,14 @@ const defaultOpts = {
  * @class
  * @param {object} opts
  * @param {string} opts.directoryUrl ACME directory URL
- * @param {buffer|string} opts.accountKey PEM encoded account private key
+ * @param {buffer|string} opts.accountKey PEM encoded account private key (only `RS256` currently supported)
  * @param {string} [opts.accountUrl] Account URL, default: `null`
  * @param {number} [opts.backoffAttempts] Maximum number of backoff attempts, default: `5`
  * @param {number} [opts.backoffMin] Minimum backoff attempt delay in milliseconds, default: `5000`
  * @param {number} [opts.backoffMax] Maximum backoff attempt delay in milliseconds, default: `30000`
  * @param {object} [opts.externalAccountBinding] EAB credentials attached to the new-account request, default: null
  * @param {object} opts.externalAccountBinding.kid EAB KID provided by CA
- * @param {object} opts.externalAccountBinding.key PEM encoded EAB HMAC Key provided by CA
+ * @param {object} opts.externalAccountBinding.key EAB HMAC Key ('secret') provided by CA (only `HS256` currently supported)
  */
 
 class AcmeClient {

--- a/src/client.js
+++ b/src/client.js
@@ -22,6 +22,7 @@ const defaultOpts = {
     directoryUrl: undefined,
     accountKey: undefined,
     accountUrl: null,
+    // externalAccountBinding: undefined,
     backoffAttempts: 5,
     backoffMin: 5000,
     backoffMax: 30000
@@ -39,6 +40,9 @@ const defaultOpts = {
  * @param {number} [opts.backoffAttempts] Maximum number of backoff attempts, default: `5`
  * @param {number} [opts.backoffMin] Minimum backoff attempt delay in milliseconds, default: `5000`
  * @param {number} [opts.backoffMax] Maximum backoff attempt delay in milliseconds, default: `30000`
+ * @param {object} [opts.externalAccountBinding] EAB credentials attached to the new-account request, default: null
+ * @param {object} opts.externalAccountBinding.kid EAB KID provided by CA
+ * @param {object} opts.externalAccountBinding.key PEM encoded EAB HMAC Key provided by CA
  */
 
 class AcmeClient {
@@ -54,9 +58,14 @@ class AcmeClient {
             min: this.opts.backoffMin,
             max: this.opts.backoffMax
         };
+        // Deep copy eab options
+        // TODO: Add pebble test instance with EAB enabled 
+        if(opts.externalAccountBinding){
+            this.opts.externalAccountBinding = Object.assign({}, opts.externalAccountBinding);
+        }
 
         this.http = new HttpClient(this.opts.directoryUrl, this.opts.accountKey);
-        this.api = new AcmeApi(this.http, this.opts.accountUrl);
+        this.api = new AcmeApi(this.http, this.opts.accountUrl, this.opts.externalAccountBinding);
     }
 
 

--- a/src/client.js
+++ b/src/client.js
@@ -59,8 +59,8 @@ class AcmeClient {
             max: this.opts.backoffMax
         };
         // Deep copy eab options
-        // TODO: Add pebble test instance with EAB enabled 
-        if(opts.externalAccountBinding){
+        // TODO: Add pebble test instance with EAB enabled
+        if (opts.externalAccountBinding) {
             this.opts.externalAccountBinding = Object.assign({}, opts.externalAccountBinding);
         }
 

--- a/test/50-client.spec.js
+++ b/test/50-client.spec.js
@@ -11,6 +11,8 @@ const directoryUrl = process.env.ACME_DIRECTORY_URL || acme.directory.letsencryp
 const capMetaTosField = !(('ACME_CAP_META_TOS_FIELD' in process.env) && (process.env.ACME_CAP_META_TOS_FIELD === '0'));
 const capUpdateAccountKey = !(('ACME_CAP_UPDATE_ACCOUNT_KEY' in process.env) && (process.env.ACME_CAP_UPDATE_ACCOUNT_KEY === '0'));
 
+console.log(`using ACME_DIRECTORY_URL: ${process.env.ACME_DIRECTORY_URL}`);
+console.log(`using ACME_EAB_DIRECTORY_URL: ${process.env.ACME_EAB_DIRECTORY_URL}`);
 
 describe('client', () => {
     let testPrivateKey;

--- a/test/51-client-eab.spec.js
+++ b/test/51-client-eab.spec.js
@@ -5,13 +5,16 @@
 const { assert } = require('chai');
 const { v4: uuid } = require('uuid');
 const Promise = require('bluebird');
-const acme = require('./../');
+const acme = require('../types');
 
-const directoryUrl = process.env.ACME_DIRECTORY_URL || acme.directory.letsencrypt.staging;
+const directoryUrl = process.env.ACME_EAB_DIRECTORY_URL || acme.directory.letsencrypt.staging;
 const capMetaTosField = !(('ACME_CAP_META_TOS_FIELD' in process.env) && (process.env.ACME_CAP_META_TOS_FIELD === '0'));
 const capUpdateAccountKey = !(('ACME_CAP_UPDATE_ACCOUNT_KEY' in process.env) && (process.env.ACME_CAP_UPDATE_ACCOUNT_KEY === '0'));
 
-describe('client', () => {
+// console.log(`using ACME_DIRECTORY_URL: ${process.env.ACME_DIRECTORY_URL}`);
+// console.log(`using ACME_EAB_DIRECTORY_URL: ${process.env.ACME_EAB_DIRECTORY_URL}`);
+
+describe('client with eab', () => {
     // non-EAB
     let testPrivateKey;
     let testSecondaryPrivateKey;
@@ -48,10 +51,18 @@ describe('client', () => {
      * Initialize clients
      */
 
-    it('should initialize client', () => {
+    it('should initialize client with eab', () => {
+        // Pull the kid info 
+        const config = require('/tmp/pebble-config-external-account-bindings.json');
+        const kid = 'kid-1';
+
         testClient = new acme.Client({
             directoryUrl,
-            accountKey: testPrivateKey
+            accountKey: testPrivateKey,
+            externalAccountBinding: {
+              kid,
+              key: config.pebble.externalAccountMACKeys[kid],
+            },
         });
     });
 

--- a/test/51-client-eab.spec.js
+++ b/test/51-client-eab.spec.js
@@ -5,7 +5,7 @@
 const { assert } = require('chai');
 const { v4: uuid } = require('uuid');
 const Promise = require('bluebird');
-const acme = require('../types');
+const acme = require('./../');
 
 const directoryUrl = process.env.ACME_EAB_DIRECTORY_URL || acme.directory.letsencrypt.staging;
 const capMetaTosField = !(('ACME_CAP_META_TOS_FIELD' in process.env) && (process.env.ACME_CAP_META_TOS_FIELD === '0'));
@@ -52,7 +52,8 @@ describe('client with eab', () => {
      */
 
     it('should initialize client with eab', () => {
-        // Pull the kid info 
+        // Pull the kid info
+        // eslint-disable-next-line global-require, import/no-absolute-path
         const config = require('/tmp/pebble-config-external-account-bindings.json');
         const kid = 'kid-1';
 
@@ -60,9 +61,9 @@ describe('client with eab', () => {
             directoryUrl,
             accountKey: testPrivateKey,
             externalAccountBinding: {
-              kid,
-              key: config.pebble.externalAccountMACKeys[kid],
-            },
+                kid,
+                key: config.pebble.externalAccountMACKeys[kid]
+            }
         });
     });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -48,7 +48,7 @@ export interface ClientOptions {
         key: string;
         /** Currently assumes HS256 */
         // alg: string;
-    }
+    };
 }
 
 export interface ClientAutoOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,15 @@ export interface ClientOptions {
     backoffAttempts?: number;
     backoffMin?: number;
     backoffMax?: number;
+    /** EAB credentials attached to the new-account request */
+    externalAccountBinding?: {
+        /** EAB KID provided by CA */
+        kid: string;
+        /** EAB HMAC Key provided by CA */
+        key: string;
+        /** Currently assumes HS256 */
+        // alg: string;
+    }
 }
 
 export interface ClientAutoOptions {

--- a/types/rfc8555.d.ts
+++ b/types/rfc8555.d.ts
@@ -47,7 +47,7 @@ export interface ExternalAccountBinding {
     /**
      * The “signature” field of the JWS will contain the
      * MAC value computed with the MAC key provided by the CA
-     * */
+     */
     signature: string;
 }
 /**
@@ -58,8 +58,10 @@ export interface ExternalAccountBindingProtectedHeader {
     alg: string;
     /** The “kid” field MUST contain the key identifier provided by the CA */
     kid: string;
-    /** field MUST be set to the same value as the outer JWS
-     * https://example.com/acme/new-account */
+    /**
+     * The 'url' field MUST be set to the same value as the outer JWS
+     * i.e. https://example.com/acme/new-account
+     */
     url: string;
 }
 

--- a/types/rfc8555.d.ts
+++ b/types/rfc8555.d.ts
@@ -6,6 +6,8 @@
  * https://tools.ietf.org/html/rfc8555#section-7.3.2
  */
 
+import { Interface } from "readline";
+
 export interface Account {
     status: 'valid' | 'deactivated' | 'revoked';
     contact?: string[];
@@ -18,7 +20,7 @@ export interface AccountCreateRequest {
     contact?: string[];
     termsOfServiceAgreed?: boolean;
     onlyReturnExisting?: boolean;
-    externalAccountBinding?: object;
+    externalAccountBinding?: ExternalAccountBinding;
 }
 
 export interface AccountUpdateRequest {
@@ -27,6 +29,39 @@ export interface AccountUpdateRequest {
     termsOfServiceAgreed?: boolean;
 }
 
+/**
+ * External Account Binding
+ * https://tools.ietf.org/html/rfc8555#section-7.3.4
+ * https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#rfc.section.7.3.4
+ */
+export interface ExternalAccountBinding {
+    /**
+     * Contains the base64 encoded instance of
+     * ExternalAccountBindingProtectedHeader
+     */
+    protected: string;
+    /**
+     * Base64 encoded public key of account key ('jwk' in outer JWS)
+     */
+    payload: string;
+    /**
+     * The “signature” field of the JWS will contain the
+     * MAC value computed with the MAC key provided by the CA
+     * */
+    signature: string;
+}
+/**
+ * Contents of the base64 encoded JWS for ExternalAccountBinding
+ */
+export interface ExternalAccountBindingProtectedHeader {
+    /** field MUST indicate a MAC-based algorithm. Usually 'HS256' */
+    alg: string;
+    /** The “kid” field MUST contain the key identifier provided by the CA */
+    kid: string;
+    /** field MUST be set to the same value as the outer JWS
+     * https://example.com/acme/new-account */
+    url: string;
+}
 
 /**
  * Order


### PR DESCRIPTION
Adds External Account Binding support.

Required for commercial CAs that implement the EAB spec in the ACME protocol ([RFC8555 - Sec 7.3.4](https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#rfc.section.7.3.4)).

_Includes Pebble test cases_

Some CAs that require EAB for ACME:
* [ZeroSSL](https://zerossl.com/documentation/acme/) - also supports free 90-day certs without Let's Encrypt's rate limits 
* [Digicert](https://docs.digicert.com/certificate-tools/Certificate-lifecycle-automation-index/acme-user-guide/)