### PR TITLE
upgrade axios to 0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "types"
     ],
     "dependencies": {
-        "axios": "0.21.0",
+        "axios": "0.21.1",
         "backo2": "^1.0.0",
         "bluebird": "^3.5.0",
         "debug": "^4.1.1",


### PR DESCRIPTION
Axios 0.21.1 fix a critical security vulnerability (see https://github.com/axios/axios/pull/3410)

fix #47 