### PR TITLE
consider ready as a valid response

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -562,7 +562,7 @@ class AcmeClient {
             else if (resp.data.status === 'pending') {
                 throw new Error('Operation is pending');
             }
-            else if (resp.data.status === 'valid') {
+            else if (resp.data.status === 'valid' || resp.data.status === 'ready') {
                 return resp.data;
             }
 


### PR DESCRIPTION
Hello,

Currently we are facing an issue that some SSL orders fail with a message `Unexpected item status: ready` which should be a valid status according to this thread: https://community.letsencrypt.org/t/acmev2-order-ready-status/62866

Seems like an old doc so I'm not sure how it went that long unnoticed, maybe it was jsut enabled for all Let's Encrypt APIs?