### PR TITLE
Upgrade axios to 0.21.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "types"
     ],
     "dependencies": {
-        "axios": "0.21.1",
+        "axios": "0.21.2",
         "backo2": "^1.0.0",
         "bluebird": "^3.5.0",
         "debug": "^4.1.1",


### PR DESCRIPTION
Axios 0.21.1 has a security issue which is causing `npm audit` to complain. Bumping it to 0.21.2 should fix the issue.