### PR TITLE
Enhance preferredChain options to allow unambiguous selection with overlapping chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.devcontainer/
 node_modules/
 npm-debug.log
 yarn-error.log

--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ await client.auto({
     skipChallengeVerification: true
 });
 ```
+### Alternate Chain Selection
+
+There are two ways to select an alternate chain (should one be available). The default way (and only way prior to v4.3.0) is to pass a string to match against the issuer. This searches each chain in order and returns the first chain in which the issuer of any of the certs in the chain `String.contains()` the string passed, or the default chain is no match is found.
+```js
+//following order finalisation
+const certificate = await client.getCertificate(order, issuer);
+```
+However this does not provide a way of unambiguously selecting an alternate chain when the same issuer string is in more than one of the chains (as is the case with the RSA chains in Lets Encrypt Staging at time of writing - 15/03/2022). To deal with this there is an option to select only by looking at the issuer of the root certificate of each chain = by passing a `preferByRoot = true`. If no match is foound the default chain is returned.
+```js
+//following order finalisation
+const certificate = await client.getCertificate(order, issuer, true);
+```
 
 
 ## API

--- a/docs/client.md
+++ b/docs/client.md
@@ -37,7 +37,7 @@ AcmeClient
     * [.verifyChallenge(authz, challenge)](#AcmeClient+verifyChallenge) ⇒ <code>Promise</code>
     * [.completeChallenge(challenge)](#AcmeClient+completeChallenge) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.waitForValidStatus(item)](#AcmeClient+waitForValidStatus) ⇒ <code>Promise.&lt;object&gt;</code>
-    * [.getCertificate(order, [preferredChain])](#AcmeClient+getCertificate) ⇒ <code>Promise.&lt;string&gt;</code>
+    * [.getCertificate(order, [preferredChain], [preferByRoot])](#AcmeClient+getCertificate) ⇒ <code>Promise.&lt;string&gt;</code>
     * [.revokeCertificate(cert, [data])](#AcmeClient+revokeCertificate) ⇒ <code>Promise</code>
     * [.auto(opts)](#AcmeClient+auto) ⇒ <code>Promise.&lt;string&gt;</code>
 
@@ -402,7 +402,7 @@ await client.waitForValidStatus(order);
 ```
 <a name="AcmeClient+getCertificate"></a>
 
-### acmeClient.getCertificate(order, [preferredChain]) ⇒ <code>Promise.&lt;string&gt;</code>
+### acmeClient.getCertificate(order, [preferredChain], [preferByRoot]) ⇒ <code>Promise.&lt;string&gt;</code>
 Get certificate from ACME order
 
 https://tools.ietf.org/html/rfc8555#section-7.4.2
@@ -414,6 +414,7 @@ https://tools.ietf.org/html/rfc8555#section-7.4.2
 | --- | --- | --- | --- |
 | order | <code>object</code> |  | Order object |
 | [preferredChain] | <code>string</code> | <code>null</code> | Indicate which certificate chain is preferred if a CA offers multiple, by exact issuer common name, default: `null` |
+| [preferByRoot] | <code>boolean</code> | <code>false</code> | If prefferedChain is not null and this is true then match issuer against root to select chain |
 
 **Example**  
 Get certificate

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "acme-client",
     "description": "Simple and unopinionated ACME client",
     "author": "nmorsman",
-    "version": "4.2.5",
+    "version": "4.3.0",
     "main": "src/index.js",
     "types": "types",
     "license": "MIT",

--- a/src/client.js
+++ b/src/client.js
@@ -610,6 +610,7 @@ class AcmeClient {
      *
      * @param {object} order Order object
      * @param {string} [preferredChain] Indicate which certificate chain is preferred if a CA offers multiple, by exact issuer common name, default: `null`
+     * @param {boolean} [preferByRoot=false] If prefferedChain is not null and this is true then match issuer against root to select chain
      * @returns {Promise<string>} Certificate
      *
      * @example Get certificate
@@ -625,7 +626,7 @@ class AcmeClient {
      * ```
      */
 
-    async getCertificate(order, preferredChain = null) {
+    async getCertificate(order, preferredChain = null, preferByRoot = false) {
         if (!validStates.includes(order.status)) {
             order = await this.waitForValidStatus(order);
         }
@@ -642,7 +643,7 @@ class AcmeClient {
             const alternates = await Promise.map(alternateLinks, async (link) => this.api.apiRequest(link, null, [200]));
             const certificates = [resp].concat(alternates).map((c) => c.data);
 
-            return util.findCertificateChainForIssuer(certificates, preferredChain);
+            return util.findCertificateChainForIssuer(certificates, preferredChain, preferByRoot);
         }
 
         /* Return default certificate chain */

--- a/test/50-client.spec.js
+++ b/test/50-client.spec.js
@@ -491,6 +491,21 @@ describe('client', () => {
         assert.strictEqual(testIssuers[0], info.issuer.commonName);
     });
 
+    it('should get alternate certificate chain when comparing only the root issuer [ACME_CAP_ALTERNATE_CERT_ROOTS]', async function() {
+        if (!capAlternateCertRoots) {
+            this.skip();
+        }
+
+        await Promise.map(testIssuers, async (issuer) => {
+            // set preferByRoot = true
+            const cert = await testClient.getCertificate(testOrder, issuer, true);
+            const rootCert = acme.forge.splitPemChain(cert).pop();
+            const info = await acme.forge.readCertificateInfo(rootCert);
+
+            assert.strictEqual(issuer, info.issuer.commonName);
+        });
+    });
+
 
     /**
      * Revoke certificate

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,7 +75,7 @@ export class Client {
     verifyChallenge(authz: Authorization, challenge: rfc8555.Challenge): Promise<boolean>;
     completeChallenge(challenge: rfc8555.Challenge): Promise<rfc8555.Challenge>;
     waitForValidStatus<T = Order | Authorization | rfc8555.Challenge>(item: T): Promise<T>;
-    getCertificate(order: Order, preferredChain?: string | null): Promise<string>;
+    getCertificate(order: Order, preferredChain?: string | null, preferByRoot?: boolean | null): Promise<string>;
     revokeCertificate(cert: CertificateBuffer | CertificateString, data?: rfc8555.CertificateRevocationRequest): Promise<void>;
     auto(opts: ClientAutoOptions): Promise<string>;
 }


### PR DESCRIPTION
Address https://github.com/publishlab/node-acme-client/issues/46 in a backwards compatible fashion.

The main driver for this was to be able to select the current alternate chain in Let's Encrypt staging - see comment on issue above.

Pebble does not seem to have a way of generating an alternate chain scenario that matches Let's Encrypt staging (i.e. the alternate chain overlaps the primary chain) however I have tested this with my use case against staging (both with and without the extra option).