### PR TITLE
Allow self-signed or invalid certificate when evaluating verifyHttpChallenge

### DIFF
--- a/src/verify.js
+++ b/src/verify.js
@@ -3,9 +3,9 @@
  */
 
 const dns = require('dns').promises;
+const https = require('https');
 const { log } = require('./logger');
 const axios = require('./axios');
-const https = require('https');
 const util = require('./util');
 
 
@@ -26,10 +26,10 @@ async function verifyHttpChallenge(authz, challenge, keyAuthorization, suffix = 
     const challengeUrl = `http://${authz.identifier.value}:${httpPort}${suffix}`;
 
     // http-01 challenge responses may redirect to https ports with self-signed or otherwise invalid certificates.
-    const httpsAgent = new https.Agent({rejectUnauthorized: false});
+    const httpsAgent = new https.Agent({ rejectUnauthorized: false });
 
     log(`Sending HTTP query to ${authz.identifier.value}, suffix: ${suffix}, port: ${httpPort}`);
-    const resp = await axios.get(challengeUrl, {httpsAgent});
+    const resp = await axios.get(challengeUrl, { httpsAgent });
     const data = (resp.data || '').replace(/\s+$/, '');
 
     log(`Query successful, HTTP status code: ${resp.status}`);


### PR DESCRIPTION
Should fix https://github.com/publishlab/node-acme-client/issues/65, although I haven't tested it yet