### PR TITLE
require extension

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,3 +21,4 @@ rules:
   no-multiple-empty-lines: [2, { max: 2, maxBOF: 0, maxEOF: 0 }]
   prefer-object-spread: 0
   import/no-useless-path-segments: 0
+  import/extensions: [2, 'always']

--- a/examples/api.js
+++ b/examples/api.js
@@ -2,7 +2,7 @@
  * Example of acme.Client API
  */
 
-const acme = require('./../');
+const acme = require('../src/index.js');
 
 
 function log(m) {

--- a/examples/auto.js
+++ b/examples/auto.js
@@ -3,7 +3,7 @@
  */
 
 // const fs = require('fs').promises;
-const acme = require('./../');
+const acme = require('../src/index.js');
 
 
 function log(m) {

--- a/src/api.js
+++ b/src/api.js
@@ -2,7 +2,7 @@
  * ACME API client
  */
 
-const util = require('./util');
+const util = require('./util.js');
 
 
 /**

--- a/src/auto.js
+++ b/src/auto.js
@@ -2,8 +2,8 @@
  * ACME auto helper
  */
 
-const { readCsrDomains } = require('./crypto');
-const { log } = require('./logger');
+const { readCsrDomains } = require('./crypto/index.js');
+const { log } = require('./logger.js');
 
 const defaultOpts = {
     csr: null,

--- a/src/axios.js
+++ b/src/axios.js
@@ -3,7 +3,7 @@
  */
 
 const axios = require('axios');
-const adapter = require('axios/lib/adapters/http');
+const adapter = require('axios/lib/adapters/http.js');
 const pkg = require('./../package.json');
 
 

--- a/src/client.js
+++ b/src/client.js
@@ -5,13 +5,13 @@
  */
 
 const { createHash } = require('crypto');
-const { getPemBodyAsB64u } = require('./crypto');
-const { log } = require('./logger');
-const HttpClient = require('./http');
-const AcmeApi = require('./api');
-const verify = require('./verify');
-const util = require('./util');
-const auto = require('./auto');
+const { getPemBodyAsB64u } = require('./crypto/index.js');
+const { log } = require('./logger.js');
+const HttpClient = require('./http.js');
+const AcmeApi = require('./api.js');
+const verify = require('./verify.js');
+const util = require('./util.js');
+const auto = require('./auto.js');
 
 
 /**

--- a/src/http.js
+++ b/src/http.js
@@ -3,9 +3,9 @@
  */
 
 const { createHmac, createSign, constants: { RSA_PKCS1_PADDING } } = require('crypto');
-const { getJwk } = require('./crypto');
-const { log } = require('./logger');
-const axios = require('./axios');
+const { getJwk } = require('./crypto/index.js');
+const { log } = require('./logger.js');
+const axios = require('./axios.js');
 
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
  * acme-client
  */
 
-exports.Client = require('./client');
+exports.Client = require('./client.js');
 
 
 /**
@@ -28,19 +28,19 @@ exports.directory = {
  * Crypto
  */
 
-exports.crypto = require('./crypto');
-exports.forge = require('./crypto/forge');
+exports.crypto = require('./crypto/index.js');
+exports.forge = require('./crypto/forge.js');
 
 
 /**
  * Axios
  */
 
-exports.axios = require('./axios');
+exports.axios = require('./axios.js');
 
 
 /**
  * Logger
  */
 
-exports.setLogger = require('./logger').setLogger;
+exports.setLogger = require('./logger.js').setLogger;

--- a/src/util.js
+++ b/src/util.js
@@ -3,8 +3,8 @@
  */
 
 const dns = require('dns').promises;
-const { readCertificateInfo, splitPemChain } = require('./crypto');
-const { log } = require('./logger');
+const { readCertificateInfo, splitPemChain } = require('./crypto/index.js');
+const { log } = require('./logger.js');
 
 
 /**

--- a/src/verify.js
+++ b/src/verify.js
@@ -3,9 +3,9 @@
  */
 
 const dns = require('dns').promises;
-const { log } = require('./logger');
-const axios = require('./axios');
-const util = require('./util');
+const { log } = require('./logger.js');
+const axios = require('./axios.js');
+const util = require('./util.js');
 
 
 /**

--- a/test/00-pebble.spec.js
+++ b/test/00-pebble.spec.js
@@ -5,8 +5,8 @@
 const dns = require('dns').promises;
 const { assert } = require('chai');
 const { v4: uuid } = require('uuid');
-const cts = require('./challtestsrv');
-const axios = require('./../src/axios');
+const cts = require('./challtestsrv.js');
+const axios = require('./../src/axios.js');
 
 const domainName = process.env.ACME_DOMAIN_NAME || 'example.com';
 const httpPort = axios.defaults.acmeSettings.httpChallengePort || 80;

--- a/test/10-http.spec.js
+++ b/test/10-http.spec.js
@@ -5,8 +5,8 @@
 const { assert } = require('chai');
 const { v4: uuid } = require('uuid');
 const nock = require('nock');
-const axios = require('./../src/axios');
-const HttpClient = require('./../src/http');
+const axios = require('./../src/axios.js');
+const HttpClient = require('./../src/http.js');
 const pkg = require('./../package.json');
 
 

--- a/test/10-logger.spec.js
+++ b/test/10-logger.spec.js
@@ -3,7 +3,7 @@
  */
 
 const { assert } = require('chai');
-const logger = require('./../src/logger');
+const logger = require('./../src/logger.js');
 
 
 describe('logger', () => {

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -4,8 +4,8 @@
 
 const { assert } = require('chai');
 const { v4: uuid } = require('uuid');
-const cts = require('./challtestsrv');
-const verify = require('./../src/verify');
+const cts = require('./challtestsrv.js');
+const verify = require('./../src/verify.js');
 
 const domainName = process.env.ACME_DOMAIN_NAME || 'example.com';
 

--- a/test/20-crypto-legacy.spec.js
+++ b/test/20-crypto-legacy.spec.js
@@ -5,8 +5,8 @@
 const fs = require('fs').promises;
 const path = require('path');
 const { assert } = require('chai');
-const spec = require('./spec');
-const forge = require('./../src/crypto/forge');
+const spec = require('./spec.js');
+const forge = require('./../src/crypto/forge.js');
 
 const cryptoEngines = {
     forge

--- a/test/20-crypto.spec.js
+++ b/test/20-crypto.spec.js
@@ -5,8 +5,8 @@
 const fs = require('fs').promises;
 const path = require('path');
 const { assert } = require('chai');
-const spec = require('./spec');
-const { crypto } = require('./../');
+const spec = require('./spec.js');
+const { crypto } = require('../src/index.js');
 
 const emptyBodyChain1 = `
 -----BEGIN TEST-----

--- a/test/50-client.spec.js
+++ b/test/50-client.spec.js
@@ -4,10 +4,10 @@
 
 const { assert } = require('chai');
 const { v4: uuid } = require('uuid');
-const cts = require('./challtestsrv');
-const getCertIssuers = require('./get-cert-issuers');
-const spec = require('./spec');
-const acme = require('./../');
+const cts = require('./challtestsrv.js');
+const getCertIssuers = require('./get-cert-issuers.js');
+const spec = require('./spec.js');
+const acme = require('../src/index.js');
 
 const domainName = process.env.ACME_DOMAIN_NAME || 'example.com';
 const directoryUrl = process.env.ACME_DIRECTORY_URL || acme.directory.letsencrypt.staging;

--- a/test/70-auto.spec.js
+++ b/test/70-auto.spec.js
@@ -4,10 +4,10 @@
 
 const { assert } = require('chai');
 const { v4: uuid } = require('uuid');
-const cts = require('./challtestsrv');
-const getCertIssuers = require('./get-cert-issuers');
-const spec = require('./spec');
-const acme = require('./../');
+const cts = require('./challtestsrv.js');
+const getCertIssuers = require('./get-cert-issuers.js');
+const spec = require('./spec.js');
+const acme = require('../src/index.js');
 
 const domainName = process.env.ACME_DOMAIN_NAME || 'example.com';
 const directoryUrl = process.env.ACME_DIRECTORY_URL || acme.directory.letsencrypt.staging;

--- a/test/challtestsrv.js
+++ b/test/challtestsrv.js
@@ -3,7 +3,7 @@
  */
 
 const { assert } = require('chai');
-const axios = require('./../src/axios');
+const axios = require('../src/axios.js');
 
 const apiBaseUrl = process.env.ACME_CHALLTESTSRV_URL || null;
 

--- a/test/get-cert-issuers.js
+++ b/test/get-cert-issuers.js
@@ -2,8 +2,8 @@
  * Get ACME certificate issuers
  */
 
-const acme = require('./../');
-const util = require('./../src/util');
+const acme = require('../src/index.js');
+const util = require('../src/util.js');
 
 const pebbleManagementUrl = process.env.ACME_PEBBLE_MANAGEMENT_URL || null;
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const dns = require('dns').promises;
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
-const axios = require('./../src/axios');
+const axios = require('../src/axios.js');
 
 
 /**


### PR DESCRIPTION
extension less is an anti pattern and it only makes it tuffer to refactor to esm, and it's harder for remote http resolver to figure out if you meant `foo.js` or `foo/index.js` when resolving paths such as `require('./foo')`

this is simply not how the web works...
or deno...