### PR TITLE
Accept partial Order object

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -309,12 +309,13 @@ class AcmeClient {
      *
      * https://datatracker.ietf.org/doc/html/rfc8555#section-7.4
      *
-     * @param {object} order Order object
+     * @param {object} order Object containing order URL
+     * @param {string} order.url Order URL
      * @returns {Promise<object>} Order
      *
      * @example
      * ```js
-     * const order = { ... }; // Previously created order object
+     * const order = { url: 'https://acme-provider.example.com/order/123' }; // Only URL is required
      * const result = await client.getOrder(order);
      * ```
      */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -65,7 +65,7 @@ export class Client {
     updateAccount(data?: rfc8555.AccountUpdateRequest): Promise<rfc8555.Account>;
     updateAccountKey(newAccountKey: PrivateKeyBuffer | PrivateKeyString, data?: object): Promise<rfc8555.Account>;
     createOrder(data: rfc8555.OrderCreateRequest): Promise<Order>;
-    getOrder(order: Order): Promise<Order>;
+    getOrder(order: Pick<Order, 'url'>): Promise<Order>;
     finalizeOrder(order: Order, csr: CsrBuffer | CsrString): Promise<Order>;
     getAuthorizations(order: Order): Promise<Authorization[]>;
     deactivateAuthorization(authz: Authorization): Promise<Authorization>;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -28,6 +28,7 @@ import * as acme from 'acme-client';
     });
 
     await client.getOrder(order);
+    await client.getOrder({ url: order.url });
 
     /* Authorizations / Challenges */
     const authorizations = await client.getAuthorizations(order);


### PR DESCRIPTION
This PR simply reduces the argument type requirements of `getOrder(order: Order)` from an object of type `Order`, to simply an object containing a URL (effectively `Pick<Order, 'url'>`). Only the Order URL is needed to retrieve an Order and re-create object, and that's how `api` [uses](https://github.com/pouwerkerk/node-acme-client/blob/master/src/api.js#L160-L162) `getOrder` anyway.  Since `api` isn't exposed to consumers of `acme-client`, I propose this modest change.

Here's an example use-case:

```typescript
const acme = require('acme-client');

const accountPrivateKey = '<PEM encoded private key>';

const client = new acme.Client({
    directoryUrl: acme.directory.letsencrypt.staging,
    accountKey: accountPrivateKey,
});

client.getOrder({ url: 'https://acme-provider.example.com/order/123' });
```

Unfortunately, TypeScript will warn the following:

> Type '{ url: string; }' is missing the following properties from type 'Order': status, identifiers, authorizations, finalize

Looking at the type definition of the `acme-client` order, I see that it actually extends the `rfc8555.Order` definition:

```typescript
export interface Order extends rfc8555.Order {
    url: string;
}
```

And creating a `rfc8555.Order` just to satisfy the function argument type requirements is onerous:
```typescript
export interface Order {
    status: 'pending' | 'ready' | 'processing' | 'valid' | 'invalid';
    identifiers: Identifier[];
    authorizations: string[];
    finalize: string;
    expires?: string;
    notBefore?: string;
    notAfter?: string;
    error?: object;
    certificate?: string;
}
```

Thanks for your consideration!