### PR TITLE
Change Axios to Xior to enable acme-client run on Cloudflare Worker

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -5,7 +5,8 @@
 const { createHmac, createSign, constants: { RSA_PKCS1_PADDING } } = require('crypto');
 const { getJwk } = require('./crypto');
 const { log } = require('./logger');
-const axios = require('./axios');
+// const axios = require('./axios');
+import xior from 'xior';
 
 /**
  * ACME HTTP client

--- a/src/http.js
+++ b/src/http.js
@@ -55,7 +55,13 @@ class HttpClient {
 
         /* Request */
         log(`HTTP request: ${method} ${url}`);
-        const resp = await axios.request(opts);
+        // const resp = await axios.request(opts);
+        let resp = await xior.request(opts);
+        const headers = {};
+        for (const [key, value] of resp.headers) {
+            headers[key] = value;
+        }
+        resp.headers = headers
 
         log(`RESP ${resp.status} ${method} ${url}`);
         return resp;


### PR DESCRIPTION
`Axios.request` is incompatible with Service Worker
It needs to be replaced with [Xior](https://github.com/suhaotian/xior) to work.
I believe there is a possibility and requirement for compatibility with Service Workers in this project
So I request a change to change Axios to Xior
See https://github.com/publishlab/node-acme-client/issues/99